### PR TITLE
rename onCleanup to deinit to have no conflicts with onCleanup in Solid

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ simplified API (I tested that every web component used in
 If you jump up to `@lift-html/core`, in the less than 600 bytes you get HMR (Hot
 Module Replacement) support, full support of web components features like
 `formAssociated` and `observedAttributes` with type safety and nice API: `init`
-and `onCleanup` callbacks instead of `constructor`, `connectedCallback`,
+and `deinit` callbacks instead of `constructor`, `connectedCallback`,
 `adoptedCallback`, `disconnectedCallback` (I yet to find an example of a web
 component that can't be written with `@lift-html/core`).
 

--- a/packages/alien/mod.ts
+++ b/packages/alien/mod.ts
@@ -50,9 +50,9 @@ export function liftAlien<
 ): LiftBaseConstructor<TAttributes, Options> {
   return liftHtml(tagName, {
     ...opts,
-    init(onCleanup) {
-      onCleanup(effectScope(() => {
-        opts.init?.call(this, onCleanup);
+    init(deinit) {
+      deinit(effectScope(() => {
+        opts.init?.call(this, deinit);
       }));
     },
   });

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -31,7 +31,7 @@ export interface LiftOptions<TAttributes extends Attributes> {
   formAssociated?: boolean | undefined;
   init(
     this: LiftBaseClass<TAttributes, LiftOptions<TAttributes>>,
-    onCleanup: (dispose: () => void) => void,
+    deinit: (dispose: () => void) => void,
   ): void;
   noHMR?: boolean;
 }
@@ -89,8 +89,7 @@ export abstract class LiftBaseClass<
 
 /**
  * Creates a custom element. The `init` function is called when the element is
- * connected to the DOM, and you can safely use Solid's reactive primitives like
- * `createEffect` and `onCleanup` and `createSignal` inside it.
+ * connected to the DOM.
  *
  * @example
  *```ts

--- a/packages/core/mod_test.ts
+++ b/packages/core/mod_test.ts
@@ -74,11 +74,11 @@ Deno.test("init is called for adoptedCallback", () => {
   assertSpyCallArgs(mockFn, 0, [element]);
 });
 
-Deno.test("onCleanup is called", () => {
+Deno.test("deinit is called", () => {
   const mockFn = spy((_element: HTMLElement) => {});
   const TestElement = liftHtml("test-element", {
-    init(onCleanup) {
-      onCleanup(() => {
+    init(deinit) {
+      deinit(() => {
         mockFn(this);
       });
     },
@@ -152,10 +152,10 @@ Deno.test("lifecycle callbacks execute in correct order", () => {
 
   const TestElement = liftHtml("test-element", {
     observedAttributes: ["test"] as const,
-    init(onCleanup) {
+    init(deinit) {
       mockInit();
       this.acb = () => mockAttrChange();
-      onCleanup(() => mockCleanup());
+      deinit(() => mockCleanup());
     },
   });
 

--- a/packages/solid/mod.ts
+++ b/packages/solid/mod.ts
@@ -50,10 +50,10 @@ export function liftSolid<
 ): LiftBaseConstructor<TAttributes, Options> {
   return liftHtml(tagName, {
     ...opts,
-    init(onCleanup) {
+    init(deinit) {
       createRoot((dispose) => {
-        opts.init?.call(this, onCleanup);
-        onCleanup(dispose);
+        opts.init?.call(this, deinit);
+        deinit(dispose);
       });
     },
   });

--- a/src/core.eta
+++ b/src/core.eta
@@ -31,7 +31,7 @@ export interface LiftOptions<TAttributes extends Attributes> {
   formAssociated?: boolean | undefined;
   init(
     this: LiftBaseClass<TAttributes, LiftOptions<TAttributes>>,
-    onCleanup: (dispose: () => void) => void,
+    deinit: (dispose: () => void) => void,
   ): void;
   noHMR?: boolean;
 }
@@ -89,8 +89,7 @@ export abstract class LiftBaseClass<
 
 /**
  * Creates a custom element. The `init` function is called when the element is
- * connected to the DOM, and you can safely use Solid's reactive primitives like
- * `createEffect` and `onCleanup` and `createSignal` inside it.
+ * connected to the DOM.
  *
  * @example
  *```ts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated lifecycle callback naming in the docs to reflect the new terminology.
  
- **Refactor**
  - Renamed the cleanup callback from "onCleanup" to "deinit" across the public API, ensuring more intuitive naming.

- **Tests**
  - Adjusted test cases to verify the updated lifecycle callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->