### PR TITLE
Automate code formatting and push changes

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,87 @@
+name: Auto Format
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: "auto-format-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  format:
+    runs-on: ubuntu-22.04
+    
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.1
+
+      - name: Check current formatting
+        id: check-format
+        run: |
+          if deno fmt --check; then
+            echo "formatted=true" >> $GITHUB_OUTPUT
+          else
+            echo "formatted=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Format code
+        if: steps.check-format.outputs.formatted == 'false'
+        run: deno fmt
+
+      - name: Check for changes
+        if: steps.check-format.outputs.formatted == 'false'
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.check-format.outputs.formatted == 'false' && steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git commit -m "🔧 Auto-format code with deno fmt"
+          git push
+
+      - name: Comment on PR
+        if: steps.check-format.outputs.formatted == 'false' && steps.changes.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🤖 I\'ve automatically formatted your code with `deno fmt` and pushed the changes to this branch.'
+            })
+
+      - name: Comment on PR (already formatted)
+        if: steps.check-format.outputs.formatted == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Your code is already properly formatted!'
+            })

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           deno-version: v2.1
 
-      - name: format
-        run: deno fmt --check
-
       - name: lint
         run: deno lint
 


### PR DESCRIPTION
Add an auto-format CI workflow to automatically format code and push changes to PR branches, and remove the format check from the publish workflow.