### PR TITLE
fix(docs): use Number instead of parseInt for infinity values

### DIFF
--- a/docs/src/content/docs/guides/example.md
+++ b/docs/src/content/docs/guides/example.md
@@ -166,8 +166,8 @@ const MyCounter = liftSolid("my-counter", {
 
     // Get configuration from attributes
     const initial = parseInt(this.getAttribute("initial") || "0");
-    const min = parseInt(this.getAttribute("min") || "-Infinity");
-    const max = parseInt(this.getAttribute("max") || "Infinity");
+    const min = Number(this.getAttribute("min") || "-Infinity");
+    const max = Number(this.getAttribute("max") || "Infinity");
     const step = parseInt(this.getAttribute("step") || "1");
 
     // Create reactive state


### PR DESCRIPTION
Using parseInt for '-Infinity' and 'Infinity' results in NaN, which breaks the bounds check. This commit replaces parseInt with Number() for the min and max attributes to correctly parse these values.